### PR TITLE
Apply Safeguards to R Install Script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,22 @@ FROM ubuntu:latest
 RUN apt-get clean && \
   apt-get update --fix-missing && \
   apt-get upgrade -y && \
-  apt-get install -y wget bzip2
+  apt-get install -y \
+  wget \
+  bzip2 \
+  unzip \
+  libcurl4-openssl-dev \
+  libssl-dev \
+  libxml2-dev \
+  libudunits2-dev \
+  zlib1g-dev \
+  libhdf5-dev
+
+# Install AWS CLI
+RUN wget "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -O awscliv2.zip && \
+  unzip awscliv2.zip && \
+  ./aws/install -i /root/aws
+ENV PATH="/root/aws/bin:${PATH}"
 
 # Install Miniconda
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
@@ -25,14 +40,9 @@ RUN conda env create -f /tmp/env.yml
 # Activate the Conda environment and run install.R
 RUN echo "source activate $(head -1 /tmp/env.yml | cut -d' ' -f2)" > ~/.bashrc
 ENV PATH /opt/conda/envs/$(head -1 /tmp/env.yml | cut -d' ' -f2)/bin:$PATH
-RUN /bin/bash -c "source /opt/conda/etc/profile.d/conda.sh && conda activate GBIF_env && Rscript /tmp/install.R"
 
-# Install AWS CLI
-RUN apt-get install -y unzip
-RUN wget "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -O awscliv2.zip && \
-  unzip awscliv2.zip && \
-  ./aws/install -i /root/aws
-ENV PATH="/root/aws/bin:${PATH}"
+# Install R packages such as rhdf5 and Phyloseq
+RUN /bin/bash -c "source /opt/conda/etc/profile.d/conda.sh && conda activate GBIF_env && Rscript /tmp/install.R"
 
 # Set the working directory
 WORKDIR /project

--- a/install.R
+++ b/install.R
@@ -1,2 +1,36 @@
-BiocManager::install("phyloseq")
+if (!requireNamespace("phyloseq", quietly = TRUE)) {
+    print("Attempting to install phyloseq")
+
+    # Install dependencies
+    deps <- c("Rhdf5lib", "rhdf5filters", "rhdf5", "biomformat")
+    for (pkg in deps) {
+        print(paste("Attempting to install", pkg))
+        if (pkg == "Rhdf5lib") {
+            install.packages("Rhdf5lib",
+                configure.args = c("--with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial"),
+                repos = BiocManager::repositories(),
+                type = "source"
+            )
+        } else {
+            BiocManager::install(pkg)
+        }
+        if (!requireNamespace(pkg, quietly = TRUE)) {
+            stop(paste("Failed to install", pkg, ". Halting execution."))
+        }
+    }
+
+    BiocManager::install("phyloseq")
+    if (!requireNamespace("phyloseq", quietly = TRUE)) {
+        stop("Failed to install phyloseq. Halting execution.")
+    }
+} else {
+    print("phyloseq is installed")
+}
+install.packages("datadogr", repos = "https://cloud.r-project.org/")
+if (!requireNamespace("datadogr", quietly = TRUE)) {
+    stop("Failed to install datadogr. Halting execution.")
+}
 install.packages("ggVennDiagram", repos = "https://cloud.r-project.org/")
+if (!requireNamespace("ggVennDiagram", quietly = TRUE)) {
+    stop("Failed to install ggVennDiagram. Halting execution.")
+}


### PR DESCRIPTION
The install.R script now halts execution when it cannot compile a dependency thus flagging the error to anyone working on the image. I still cannot get phyloseq to compile on the docker image. The problem is the Rhdf5lib dependency does not compile the static library of hdf5. We may need to hire a specialist to troubleshoot the compilation process. I'll open up an issue on GitHub with more details.